### PR TITLE
Update .gitignore to ignore tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+doc/tags
+.tags


### PR DESCRIPTION
I use git submodules to manage my vim plugins.

Everytime I generate tags, my vim submodules becomes dirty.

It is common to add tags files to the ignore to prevent this issue.
- https://github.com/vimwiki/vimwiki/blob/dev/.gitignore#L4